### PR TITLE
Fix windows execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - Add power constant laser power (Sx) #TODO: variable power for grayscale *not working
 - Consolidate Feed (=speed Fx) and Speed(=power Sx) to gcode header
 - Moved LASER ON / LASER OFF to begin/end file only
+- Added option to set laser max power GCode (usually 255)
 
 
 ----------- ORIGINAL TEXT -----------------

--- a/raster2laser_gcode.inx
+++ b/raster2laser_gcode.inx
@@ -75,6 +75,7 @@
 
 	<param name="laseron" type="string"  gui-text="Laser ON Command">M03</param>
 	<param name="laseroff" type="string"  gui-text="Laser OFF Command">M05</param>
+	<param name="laser_max_value" type="int" min="1" max="12000" gui-text="Laser max power value">255</param>
 
 	<effect needs-live-preview="false">
         <object-type>all</object-type>

--- a/raster2laser_gcode.inx
+++ b/raster2laser_gcode.inx
@@ -4,27 +4,27 @@
 	<name>Raster 2 Laser GCode generator</name>
 	<!-- il campo ID deve essere univoco  -->
 	<id>com.305engineering.raster2laser_gcode</id>
-	
+
 	<!-- Dipendenze, basta solo lo script python principale -->
 	<!-- <dependency type="executable" location="extensions">raster2laser_gcode.py</dependency> -->
 	<!-- <dependency type="executable" location="extensions">inkex.py</dependency> -->
-	    	
+
 	<!-- Titolo e descrizione -->
 	<param name="Title" type="description">Raster 2 Laser GCode generator</param>
 	<param name="Description" type="description">created by 305 Engineering - Tweaked to work on Inkscape 1.x (+BFerrarese)</param>
-    
+
 	<!-- Opzioni di esportazione dell'immagine -->
 	<param name="directory" type="string"  gui-text="Export directory"></param>
 	<param name="filename" type="string"  gui-text="File Name"></param>
 	<param name="add-numeric-suffix-to-filename" type="boolean" gui-text="Add numeric suffix to filename">true</param>
-			
+
 	<param name="resolution" type="enum" gui-text="Resolution">
 		<_item value="1">1 pixel/mm</_item>
 		<_item value="2">2 pixel/mm</_item>
 		<_item value="5">5 pixel/mm</_item>
 		<_item value="10">10 pixel/mm</_item>
 	</param>
-		
+
 	<!-- Come convertire in scala di grigi -->
 	<param name="grayscale_type" type="enum" gui-text="Color to Grayscale conversion">
 		<_item value="1">0.21R + 0.71G + 0.07B</_item>
@@ -35,7 +35,7 @@
 		<_item value="6">Max Color</_item>
 		<_item value="7">Min Color</_item>
 	</param>
-	
+
 	<!-- Modalità di conversione in Bianco e Nero -->
 	<param name="conversion_type" type="enum" gui-text="B/W conversion algorithm ">
 		<_item value="1">B/W fixed threshold</_item>
@@ -45,10 +45,10 @@
 		<_item value="5">Halftone column</_item>
 		<_item value="6">Grayscale</_item>
 	</param>
-	
+
 	<!-- Opzioni modalita -->
 	<param name="BW_threshold" type="int" min="1" max="254" gui-text="B/W threshold">128</param>
-	
+
 	<param name="grayscale_resolution" type="enum" gui-text="Grayscale resolution ">
 		<_item value="1">256</_item>
 		<_item value="2">128</_item>  <!-- 256/2 -->
@@ -56,13 +56,13 @@
 		<_item value="8">32</_item>  <!-- 256/8 -->
 		<_item value="16">16</_item>  <!-- 256/16 -->
 		<_item value="32">8</_item>  <!-- 256/32 -->
-	</param>	
+	</param>
 
-	
+
 	<!-- Velocità Nero e spostamento -->
 	<param name="feed" type="int" min="1" max="5000" gui-text="Engraving speed">200</param>
 	<param name="power" type="int" min="1" max="100" gui-text="Laser power %">80</param>
-	
+
 	<!-- FLIP = coordinate Cartesiane (False) Coordinate "informatiche" (True) -->
 	<param name="flip_y" type="boolean" gui-text="Flip Y">false</param>
 
@@ -72,17 +72,17 @@
 		<_item value="2">$H (GRBL)</_item>
 		<_item value="3">No Homing</_item>
 	</param>
-	
+
 	<param name="laseron" type="string"  gui-text="Laser ON Command">M03</param>
 	<param name="laseroff" type="string"  gui-text="Laser OFF Command">M05</param>
-	
-	<effect needs-live-preview="false"> 
+
+	<effect needs-live-preview="false">
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="305 Engineering"/>
         </effects-menu>
     </effect>
-    
+
 	<!-- Script python da eseguire -->
 	<script>
     	<command reldir="extensions" interpreter="python">raster2laser_gcode.py</command>

--- a/raster2laser_gcode.py
+++ b/raster2laser_gcode.py
@@ -76,6 +76,7 @@ class GcodeExport(inkex.Effect):
         # Commands
         self.arg_parser.add_argument("-lon", "--laseron", type=str, dest="laseron", default="M03", help="")
         self.arg_parser.add_argument("-loff", "--laseroff", type=str, dest="laseroff", default="M05", help="")
+        self.arg_parser.add_argument("-mp", "--laser_max_value", type=int, dest="laser_max_value", default="255", help="")
 
         #inkex.errormsg("BLA BLA BLA Messaggio da visualizzare") #DEBUG
 
@@ -382,7 +383,8 @@ class GcodeExport(inkex.Effect):
 
         Laser_ON = False
         Feed = self.options.feed * 60
-        Power = self.options.power * 255/100
+        LaserMaxValue = self.options.laser_max_value
+        Power = self.options.power * LaserMaxValue/100
         Scala = self.options.resolution
         file_gcode = open(pos_file_gcode, 'w')  #Creo il file
 
@@ -447,8 +449,8 @@ class GcodeExport(inkex.Effect):
                     for x in range(w):
                         if matrice_BN[y][x] != B:
                             if not Laser_ON:
-                                file_gcode.write('G0 X' + str(float(x)/Scala) + ' Y' + str(float(y)/Scala) + ' S' + str(255 - matrice_BN[y][x]) +'\n')
-                                # file_gcode.write(self.options.laseron + ' '+ ' S' + str(255 - matrice_BN[y][x]) +'\n')
+                                file_gcode.write('G0 X' + str(float(x)/Scala) + ' Y' + str(float(y)/Scala) + ' S' + str(LaserMaxValue - matrice_BN[y][x]) +'\n')
+                                # file_gcode.write(self.options.laseron + ' '+ ' S' + str(LaserMaxValue - matrice_BN[y][x]) +'\n')
                                 Laser_ON = True
 
                             if  Laser_ON:   #DEVO evitare di uscire dalla matrice
@@ -462,16 +464,16 @@ class GcodeExport(inkex.Effect):
                                         Laser_ON = False
 
                                     elif matrice_BN[y][x] != matrice_BN[y][x+1]:
-                                        file_gcode.write('G1 X' + str(float(x+1)/Scala) + ' Y' + str(float(y)/Scala) + ' S' + str(255 - matrice_BN[y][x+1]) +'\n')
-                                        # file_gcode.write(self.options.laseron + ' '+ ' S' + str(255 - matrice_BN[y][x+1]) +'\n')
+                                        file_gcode.write('G1 X' + str(float(x+1)/Scala) + ' Y' + str(float(y)/Scala) + ' S' + str(LaserMaxValue - matrice_BN[y][x+1]) +'\n')
+                                        # file_gcode.write(self.options.laseron + ' '+ ' S' + str(LaserMaxValue - matrice_BN[y][x+1]) +'\n')
 
 
                 else:
                     for x in reversed(range(w)):
                         if matrice_BN[y][x] != B:
                             if not Laser_ON:
-                                file_gcode.write('G0 X' + str(float(x+1)/Scala) + ' Y' + str(float(y)/Scala) + ' S' + str(255 - matrice_BN[y][x]) +'\n')
-                                # file_gcode.write(self.options.laseron + ' '+ ' S' + str(255 - matrice_BN[y][x]) +'\n')
+                                file_gcode.write('G0 X' + str(float(x+1)/Scala) + ' Y' + str(float(y)/Scala) + ' S' + str(LaserMaxValue - matrice_BN[y][x]) +'\n')
+                                # file_gcode.write(self.options.laseron + ' '+ ' S' + str(LaserMaxValue - matrice_BN[y][x]) +'\n')
                                 Laser_ON = True
 
                             if  Laser_ON:   #DEVO evitare di uscire dalla matrice
@@ -485,8 +487,8 @@ class GcodeExport(inkex.Effect):
                                         Laser_ON = False
 
                                     elif  matrice_BN[y][x] != matrice_BN[y][x-1]:
-                                        file_gcode.write('G1 X' + str(float(x)/Scala) + ' Y' + str(float(y)/Scala) + ' S' + str(255 - matrice_BN[y][x-1]) +'\n')
-                                        # file_gcode.write(self.options.laseron + ' '+ ' S' + str(255 - matrice_BN[y][x-1]) +'\n')
+                                        file_gcode.write('G1 X' + str(float(x)/Scala) + ' Y' + str(float(y)/Scala) + ' S' + str(LaserMaxValue - matrice_BN[y][x-1]) +'\n')
+                                        # file_gcode.write(self.options.laseron + ' '+ ' S' + str(LaserMaxValue - matrice_BN[y][x-1]) +'\n')
 
 
 

--- a/raster2laser_gcode.py
+++ b/raster2laser_gcode.py
@@ -95,7 +95,7 @@ class GcodeExport(inkex.Effect):
                 for s in dir_list:
                     r = re.match("^%s_0*(\d+).*%s$"%(re.escape(temp_name), '\\.png'), s)
                     if r:
-                        max_n = max(max_n, int(r.group(1)))	
+                        max_n = max(max_n, int(r.group(1)))
                 self.options.filename = temp_name + "_" + ("0"*(4-len(str(max_n+1))) + str(max_n+1))
 
             #genero i percorsi file da usare

--- a/raster2laser_gcode.py
+++ b/raster2laser_gcode.py
@@ -93,7 +93,7 @@ class GcodeExport(inkex.Effect):
                 temp_name = self.options.filename
                 max_n = 0
                 for s in dir_list:
-                    r = re.match("^%s_0*(\d+)%s$"%(re.escape(temp_name), '.png'), s)
+                    r = re.match("^%s_0*(\d+).*%s$"%(re.escape(temp_name), '\\.png'), s)
                     if r:
                         max_n = max(max_n, int(r.group(1)))	
                 self.options.filename = temp_name + "_" + ("0"*(4-len(str(max_n+1))) + str(max_n+1))

--- a/raster2laser_gcode.py
+++ b/raster2laser_gcode.py
@@ -162,9 +162,11 @@ class GcodeExport(inkex.Effect):
         else:
             DPI = 254
 
-        command = "inkscape -C -o \"%s\" -d %s -y 1 %s 2>/dev/null" % (pos_file_png_original, DPI, current_file) #Comando da linea di comando per esportare in PNG
-        p = subprocess.Popen(command, shell=True)
+        command = "inkscape -C -o \"%s\" -d %s -y 1 %s" % (pos_file_png_original, DPI, current_file)  #Comando da linea di comando per esportare in PNG
+
+        p = subprocess.Popen(command, shell=True, stderr=subprocess.PIPE)
         p.wait()
+        p.stderr.close()
 
 
 


### PR DESCRIPTION
This request introduces three changes **in three separate commits**, with the fourth one just removing trailing whitespaces from the source code. It might be easier to look at the changes of these commits individually, instead of at the full diff of this PR, as it has noise from the whitespace removal.

Each functional change is explained below:

## Fix PNG export on Windows

As discussed in #2 I took a look at the export on Windows, and it turns out the reason the PNG file doesn't get created is that the `inkscape` command (started around line 166 in raster2laser_gcode.py) seems to fail with a return code of 1, without anything in its `stdout`. The `stderr` had been manually redirected to `/dev/null`. When I removed this part of the command to study the failure, everything went well.

So the change is to use `subprocess`'s built-in stream redirection to pipe `stderr` to a python stream, which we just close when the process is done (we could print a warning to the user, but I suspect the original `2>/dev/null` implementation expected some warnings anyway).

## Fix regex for numeric increment

This regex was somehow broken, and it would not detect pre-existing "name_XXXX_something.png" files to pick a unique numeric component. With the new one it does detect it and increments properly.

## Option to change laser max power GCode value

On most machines this value is usually 255, but sometimes it goes to 1000 (in my case), or even 12000, depending on the interpreter. This defaults to 255, but lets people change it easily should they need to.


**Note**: All of the changes above have been tested on my Windows 10 machine, and I gave it a quick test on a Catalina MacBook I have. Everything looks fine, but I would test on your system as well, just to triple check 😄

By the way, thanks for porting this extension to Inkscape 1.0 in the first place!