### PR TITLE
Feature: Overscan Support

### DIFF
--- a/raster2laser_gcode.inx
+++ b/raster2laser_gcode.inx
@@ -79,6 +79,14 @@
 	<param name="laser_max_value" type="int" min="1" max="12000" gui-text="Laser max power value">255</param>
 	<param name="laserminsw" type="boolean" gui-text="ON/OFF only at the beginning and end of the file">true</param>
 
+	<param name="overscan_distance" type="enum" gui-text="Overscan  ">
+		<_item value="0">Disabled</_item>
+		<_item value="5">5 mm</_item>
+		<_item value="10">10 mm</_item>
+		<_item value="20">20 mm</_item>
+		<_item value="40">40 mm</_item>
+	</param>
+
 	<effect needs-live-preview="false">
         <object-type>all</object-type>
         <effects-menu>

--- a/raster2laser_gcode.py
+++ b/raster2laser_gcode.py
@@ -30,6 +30,7 @@ import re
 sys.path.append('/usr/share/inkscape/extensions')
 sys.path.append('/Applications/Inkscape.app/Contents/Resources/share/inkscape/extensions')
 
+import math
 import subprocess
 
 import inkex
@@ -426,10 +427,12 @@ class GcodeExport(inkex.Effect):
         if self.options.conversion_type != 6:
             for y in range(h):
                 scanline_first = True
+                scanline_last = float('nan')
                 if y % 2 == 0:
                     for x in range(w):
                         if matrice_BN[y][x] == N:
-                            if scanline_first:
+                            scanline_last = x
+                            if overscan > 0 and scanline_first:
                                 scanline_first = False
                                 file_gcode.write('G0 X' + str(float(max(0, x - overscan)) / Scala) + ' Y' + str(float(y) / Scala) + '\n')
                             if not Laser_ON:
@@ -449,10 +452,14 @@ class GcodeExport(inkex.Effect):
                                         if not self.options.laserminsw:
                                             file_gcode.write(self.options.laseroff + '\n')
                                         Laser_ON = False
+                    if overscan > 0 and not math.isnan(scanline_last):
+                        file_gcode.write('G0 X' + str(float(scanline_last + overscan) / Scala) + ' Y' + str(
+                            float(y) / Scala) + '\n')
                 else:
                     for x in reversed(range(w)):
                         if matrice_BN[y][x] == N:
-                            if scanline_first:
+                            scanline_last = x
+                            if overscan > 0 and scanline_first:
                                 scanline_first = False
                                 file_gcode.write('G0 X' + str(float(x + overscan) / Scala) + ' Y' + str(float(y) / Scala) + '\n')
                             if not Laser_ON:
@@ -472,14 +479,19 @@ class GcodeExport(inkex.Effect):
                                         if not self.options.laserminsw:
                                             file_gcode.write(self.options.laseroff + '\n')
                                         Laser_ON = False
+                    if overscan > 0 and not math.isnan(scanline_last):
+                        file_gcode.write('G0 X' + str(float(max(scanline_last - overscan, 0)) / Scala) + ' Y' + str(
+                            float(y) / Scala) + '\n')
 
         else: ##SCALA DI GRIGI
             for y in range(h):
                 scanline_first = True
+                scanline_last = float('nan')
                 if y % 2 == 0:
                     for x in range(w):
                         if matrice_BN[y][x] != B:
-                            if scanline_first:
+                            scanline_last = x
+                            if overscan > 0 and scanline_first:
                                 scanline_first = False
                                 file_gcode.write('G0 X' + str(float(max(0, x - overscan)) / Scala) + ' Y' + str(float(y) / Scala) + '\n')
                             if not Laser_ON:
@@ -510,12 +522,16 @@ class GcodeExport(inkex.Effect):
                                         else:
                                             file_gcode.write('G1 X' + str(float(x+1)/Scala) + ' Y' + str(float(y)/Scala) +'\n')
                                             file_gcode.write(self.options.laseron + ' '+ ' S' + str(LaserMaxValue - matrice_BN[y][x+1]) +'\n')
+                    if not overscan > 0 and math.isnan(scanline_last):
+                        file_gcode.write('G0 X' + str(float(scanline_last + overscan) / Scala) + ' Y' + str(
+                            float(y) / Scala) + '\n')
 
 
                 else:
                     for x in reversed(range(w)):
                         if matrice_BN[y][x] != B:
-                            if scanline_first:
+                            scanline_last = x
+                            if overscan > 0 and scanline_first:
                                 scanline_first = False
                                 file_gcode.write('G0 X' + str(float(x + overscan) / Scala) + ' Y' + str(float(y) / Scala) + '\n')
                             if not Laser_ON:
@@ -546,6 +562,8 @@ class GcodeExport(inkex.Effect):
                                         else:
                                             file_gcode.write('G1 X' + str(float(x)/Scala) + ' Y' + str(float(y)/Scala) +'\n')
                                             file_gcode.write(self.options.laseron + ' '+ ' S' + str(LaserMaxValue - matrice_BN[y][x-1]) +'\n')
+                    if overscan > 0 and not math.isnan(scanline_last):
+                        file_gcode.write('G0 X' + str(float(max(scanline_last - overscan, 0)) / Scala) + ' Y' + str(float(y) / Scala) + '\n')
 
 
 


### PR DESCRIPTION
Hi! I used this extension to do some laser engraving, and wrote a feature that might be useful.

Thanks for updating the `bferrarese/raster2laser_gcode` extension for the latest version of Inkscape (1.x).
I believe your fork is the most popular one out there and would have the most community impact.

When laser engraving at high speed, the cutter head tends to slow down over the edges of the path as it decelerates and accelerates in the opposite direction.
This could create burns and over-exposure at the edge of the engraved pattern.

Here are two samples: the first engraving has burnt edges, and the second uses overscan for a cleaner engraving.

![Without Overscan - laser engraved text with burnt edges](https://user-images.githubusercontent.com/710625/209967270-aee06bfb-79b9-4c02-8349-8042aca8b5c8.jpeg)
![With Overscan - laser engraved text without burnt edges](https://user-images.githubusercontent.com/710625/209967292-17740de1-5377-4fde-b866-0bc910d10b3e.jpeg)

I've written an overscan feature which solves this problem. Increasing overscan distance gives the cutter head more space to accelerate before lasing, yielding better results at the expense of slightly longer process duration.

Here's a screenshot of the new overscan parameter dropdown:
![screenshot of extension settings window with overscan parameter options displayed](https://user-images.githubusercontent.com/710625/209966723-dac9367f-d91d-4383-929a-a910c5ccb476.png)

Thanks again for keeping this extension alive! I hope this helps.

P.S. To help with the maintainability and my own understanding, I've added English translations for both new and existing code. If you'd prefer that these changes were submitted separately, just let me know.
